### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/SuiteEngine/7d8b9f81-907f-4687-b97d-5c1678f42243/a5b8197d-3d54-407f-8bc9-c3b9f3a0981d/_apis/work/boardbadge/0346fd5c-543a-445c-961d-554f15d4612b)](https://dev.azure.com/SuiteEngine/7d8b9f81-907f-4687-b97d-5c1678f42243/_boards/board/t/a5b8197d-3d54-407f-8bc9-c3b9f3a0981d/Microsoft.RequirementCategory)
 # NAV Container Helper
 
 This repository contains a module, which makes it easier to work with Nav Containers on Docker.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/SuiteEngine/7d8b9f81-907f-4687-b97d-5c1678f42243/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.